### PR TITLE
Initialize scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM onmodulus/build-base
+
+ADD . /opt/modulus
+ENV PATH=/opt/modulus/bin:$PATH
+RUN /opt/modulus/bootstrap.sh
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]

--- a/bin/build
+++ b/bin/build
@@ -7,29 +7,31 @@ if [[ ! $INPUT_DIR ]] || [[ ! $OUTPUT_DIR ]]; then
 fi
 
 mkdir -p $INPUT_DIR
-mkdir -p $OUTPUT_DIR
 
-if [[ ! -d $INPUT_DIR ]] || [[ ! -d $OUTPUT_DIR ]]; then
-  echo "Input/Output directories must exist."
+if [[ ! -d $INPUT_DIR ]]; then
+  echo "Input directory must exist."
   exit 1
 fi
 
+# move contents of input to output
+if [[ -d $OUTPUT_DIR ]]; then
+  rm -rf $OUTPUT_DIR
+fi
+mv $INPUT_DIR $OUTPUT_DIR
+
+# import home from image
 cp -R /opt/home/. $HOME
 
-# mv $INPUT_DIR/{*,.*} $OUTPUT_DIR > /dev/null 2>&1
-cp -R $INPUT_DIR/. $OUTPUT_DIR
-
-MOD_DIR=$OUTPUT_DIR/.modulus
-mkdir -p $MOD_DIR
-
-source $HOME/.dnx/dnvm/dnvm.sh
-
 # use dnvm to install .net core
+source $HOME/.dnx/dnvm/dnvm.sh
 echo "dnvm upgrade -r coreclr"
 dnvm upgrade -r coreclr
 
 cd $OUTPUT_DIR
 echo "dnu restore"
 dnu restore
+
+MOD_DIR=$OUTPUT_DIR/.modulus
+mkdir -p $MOD_DIR
 
 mv $HOME $MOD_DIR/home

--- a/bin/build
+++ b/bin/build
@@ -32,4 +32,4 @@ cd $OUTPUT_DIR
 echo "dnu restore"
 dnu restore
 
-cp -R $HOME/. $MOD_DIR/home
+mv $HOME $MOD_DIR/home

--- a/bin/build
+++ b/bin/build
@@ -25,7 +25,7 @@ cp -R /opt/home/. $HOME
 # use dnvm to install .net core
 source $HOME/.dnx/dnvm/dnvm.sh
 echo "dnvm upgrade -r coreclr"
-dnvm upgrade -r coreclr
+dnvm upgrade -r coreclr > /dev/null 2>&1
 
 cd $OUTPUT_DIR
 echo "dnu restore"

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ ! $INPUT_DIR ]] || [[ ! $OUTPUT_DIR ]]; then
+  echo "Input/Output directory variables must be set."
+  exit 1
+fi
+
+mkdir -p $INPUT_DIR
+mkdir -p $OUTPUT_DIR
+
+if [[ ! -d $INPUT_DIR ]] || [[ ! -d $OUTPUT_DIR ]]; then
+  echo "Input/Output directories must exist."
+  exit 1
+fi
+
+cp -R /opt/home/. $HOME
+
+# mv $INPUT_DIR/{*,.*} $OUTPUT_DIR > /dev/null 2>&1
+cp -R $INPUT_DIR/. $OUTPUT_DIR
+
+MOD_DIR=$OUTPUT_DIR/.modulus
+mkdir -p $MOD_DIR
+
+source $HOME/.dnx/dnvm/dnvm.sh
+
+# use dnvm to install .net core
+echo "dnvm upgrade -r coreclr"
+dnvm upgrade -r coreclr
+
+cd $OUTPUT_DIR
+echo "dnu restore"
+dnu restore
+
+cp -R $HOME/. $MOD_DIR/home

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,3 +29,4 @@ cd ~/ && ldconfig
 
 # clean up
 apt-get autoclean && apt-get autoremove -y && apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+export TMPDIR=/tmp
+export HOME=/opt/home
+
+apt-get update
+
+# install the .NET Version Manager (DNVM)
+apt-get install -y unzip curl
+curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh \
+  | DNX_BRANCH=dev sh
+
+# install dnx prerequisite
+apt-get install -y libunwind8 gettext libssl-dev libcurl4-openssl-dev zlib1g \
+  libicu-dev uuid-dev
+
+# install Libuv
+apt-get -y install make automake libtool
+curl -sSL https://github.com/libuv/libuv/archive/v1.8.0.tar.gz \
+  | tar zxfv - -C /usr/local/src
+cd /usr/local/src/libuv-1.8.0
+sh autogen.sh
+./configure
+make
+make install
+rm -rf /usr/local/src/libuv-1.8.0
+cd ~/ && ldconfig
+
+# clean up
+apt-get autoclean && apt-get autoremove -y && apt-get clean


### PR DESCRIPTION
Use build-base and bootstrap script to install dependencies. Build
script sources dnvm, update coreclr, and restores app dependencies. Home
directory is copied into build output for use at runtime.
